### PR TITLE
Escape new lines and quotes for teamcity

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -68,6 +68,13 @@ module.exports = function(grunt) {
   grunt.registerTask('isolated_test', function(){
     grunt.log.warn('foo-bar-uniqe-string');
   });
+  grunt.registerTask('isolated_test_single_quotes', function(){
+    grunt.log.warn("single'quote");
+  });
+  grunt.registerTask('isolated_test_line_breaks', function(){
+    grunt.log.warn("new\n line");
+  });
+
   grunt.registerTask('isolated_test_parse_twice', function(){
     grunt.log.warn("##teamcity['someMessage']");
   });

--- a/tasks/teamcity.js
+++ b/tasks/teamcity.js
@@ -77,9 +77,13 @@ module.exports = function(grunt) {
         return text;
       }
 
-      return  ("##teamcity[message text='" + text +
-        "' errorDetails='" + (errorDetails || '') +
-        "' status='" + status + "']\n").grey;
+      return  ("##teamcity[message text='" + escape(text) +
+        "' errorDetails='" + escape(errorDetails || '') +
+        "' status='" + escape(status) + "']\n").grey;
+    }
+
+    function escape(text){
+      return (text || '').replace("'","|'").replace("\n","|n").replace("\r","|r").replace("\f","|f");
     }
 
     // verbatum from grunt.log

--- a/test/teamcity_test.js
+++ b/test/teamcity_test.js
@@ -83,5 +83,35 @@ exports.teamcity = {
       test.equal(tcMsgCount, 0, 'Teamcity messages are not parsed twice');
       test.done();
     });
+  },
+  single_quote_escaping: function(test) {
+    test.expect(1);
+    exec('grunt teamcity:default_options isolated_test_single_quotes --no-color', function(err, stdout){
+      var tcMsgCount = 0;
+      stdout.split('\n').forEach(function(line){
+        console.log(line);
+        if (line.contains("##teamcity[message text='single|'quote' errorDetails='' status='ERROR'")) {
+          tcMsgCount++;
+        }
+      });
+
+      test.equal(tcMsgCount, 1, 'Single quotes are encoded');
+      test.done();
+    });
+  },
+  line_break_escaping: function(test) {
+    test.expect(1);
+    exec('grunt teamcity:default_options isolated_test_line_breaks --no-color', function(err, stdout){
+      var tcMsgCount = 0;
+      stdout.split('\n').forEach(function(line){
+        console.log(line);
+        if (line.contains("##teamcity[message text='new|n line' errorDetails='' status='ERROR'")) {
+          tcMsgCount++;
+        }
+      });
+
+      test.equal(tcMsgCount, 1, 'Line breaks are stripped');
+      test.done();
+    });
   }
 };


### PR DESCRIPTION
Teamcity requires line breaks and single quotes to be escaped, see http://confluence.jetbrains.com/display/TCD8/Build+Script+Interaction+with+TeamCity#BuildScriptInteractionwithTeamCity-ServiceMessages.

This commit adds escaping to the grunt log.
